### PR TITLE
Use password stored in an environmental variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,20 @@ Finally, edit your `package.json` to add the `encrypt` and `decrypt` scripts, su
 
 Here, the `encrypt` script will encrypt the `config.json` file as `config.json.cast5`, and the `decrypt` script will decrypt the `config.json.cast5` file as `config.json`. In both cases, the name of the encrypted file can be chosen arbitrarily.
 
+You can choose to bypass manual password entry by supplying the name of an environmental variable you have set to store a password for you using the `--PW` flag:
+```json
+{
+  "name": "my-project",
+  "version": "0.0.1",
+  "scripts": {
+    ...
+    "encrypt": "encrypt config.json config.json.cast5 --PW=ENV_VAR_PW_KEY",
+    "decrypt": "decrypt config.json.cast5 config.json --PW=ENV_VAR_PW_KEY"
+  }
+}
+```
+
+
 Usage
 -----
 

--- a/index.js
+++ b/index.js
@@ -1,51 +1,63 @@
-var crypto   = require("crypto")
-var fs       = require("fs")
+var crypto	 = require("crypto")
+var fs			 = require("fs")
 var readline = require("readline")
-var path     = require("path")
+var path		 = require("path")
 
 module.exports = function(fn) {
-  var from = path.join(process.cwd(), process.argv[2])
-  var to   = path.join(process.cwd(), process.argv[3])
+	var argv = require('minimist')(process.argv.slice(2));
+	var from = path.join(process.cwd(), process.argv[2])
+	var to	 = path.join(process.cwd(), process.argv[3])
 
-  var rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout
-  })
+	var rl = readline.createInterface({
+		input: process.stdin,
+		output: process.stdout
+	})
 
-  var input = function(query, callback) {
-    var stdin = process.openStdin(),
-        i = 0;
-    process.stdin.on("data", function(char) {
-        char = char + "";
-        switch (char) {
-            case "\n":
-            case "\r":
-            case "\u0004":
-                stdin.pause();
-                break;
-            default:
-                process.stdout.write("\033[2K\033[200D" + Array(rl.line.length+1).join("*"));
-		i++;
-                break;
-        }
-    });
+	var input = function(query, callback) {
+		if (argv.PW){
+      if(process.env[argv.PW]){
+        callback(process.env[argv.PW]);
+        process.exit();
+      }else{
+        console.error(new Error("Environmental variable \""+argv.PW+"\" has not been set."));
+        process.exit(1)
+      }
+      
+		}else{
+			var stdin = process.openStdin(),
+					i = 0;
+			process.stdin.on("data", function(char) {
+					char = char + "";
+					switch (char) {
+							case "\n":
+							case "\r":
+							case "\u0004":
+									stdin.pause();
+									break;
+							default:
+									process.stdout.write("\033[2K\033[200D" + Array(rl.line.length+1).join("*"));
+			i++;
+									break;
+					}
+			});
 
-    rl.question(query, function(value) {
-        rl.history = rl.history.slice(1);
-        callback(value);
-    });
-  }
-  
-  input("Enter the config password ("+path.basename(to)+"):\n", function(password) {
+			rl.question(query, function(value) {
+					rl.history = rl.history.slice(1);
+					callback(value);
+			});
+		}
+	}
+	
+	input("Enter the config password ("+path.basename(to)+"):\n", function(password) {
     from = fs.createReadStream(from)
     to   = fs.createWriteStream(to)
-    fn   = fn("cast5-cbc", password)
+		fn	 = fn("cast5-cbc", password)
 
-    from.pipe(fn).pipe(to)
-    from.on("end", function () {
-      rl.write("done\n");
-      rl.close.bind(rl);
-    });
-    
-  })
+		from.pipe(fn).pipe(to)
+		from.on("end", function () {
+			rl.write("done\n");
+			rl.close.bind(rl);
+		});
+		
+	})
 }

--- a/index.js
+++ b/index.js
@@ -15,14 +15,12 @@ module.exports = function(fn) {
 
 	var input = function(query, callback) {
 		if (argv.PW){
-      if(process.env[argv.PW]){
-        callback(process.env[argv.PW]);
-        process.exit();
-      }else{
-        console.error(new Error("Environmental variable \""+argv.PW+"\" has not been set."));
-        process.exit(1)
-      }
-      
+			if(process.env[argv.PW]){
+				callback(process.env[argv.PW], true);
+			}else{
+				console.error(new Error("Environmental variable \""+argv.PW+"\" has not been set."));
+				process.exit(1)
+	  		}
 		}else{
 			var stdin = process.openStdin(),
 					i = 0;
@@ -48,16 +46,19 @@ module.exports = function(fn) {
 		}
 	}
 	
-	input("Enter the config password ("+path.basename(to)+"):\n", function(password) {
-    from = fs.createReadStream(from)
-    to   = fs.createWriteStream(to)
+	input("Enter the config password ("+path.basename(to)+"):\n", function(password, env_var_bool) {
+		from = fs.createReadStream(from)
+		to   = fs.createWriteStream(to)
 		fn	 = fn("cast5-cbc", password)
 
 		from.pipe(fn).pipe(to)
 		from.on("end", function () {
 			rl.write("done\n");
-			rl.close.bind(rl);
+			if(!env_var_bool){
+				rl.close.bind(rl);
+			}else{
+				process.exit();
+			}
 		});
-		
 	})
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,12 @@
   "scripts": {
     "test": "sh test.sh",
     "encrypt": "encrypt config.json config.json.cast5",
-    "decrypt": "decrypt config.json.cast5 config.copy.json"
+    "decrypt": "decrypt config.json.cast5 config.copy.json",
+    "encrypt_env": "encrypt config.json config.json.cast5 --PW=ENV_PW",
+    "decrypt_env": "decrypt config.json.cast5 config.copy.json --PW=ENV_PW"
+  },
+  "dependencies": {
+    "minimist":"^1.2.0"
   },
   "bin": {
     "encrypt": "./encrypt.js",

--- a/test.sh
+++ b/test.sh
@@ -9,3 +9,12 @@ echo "cynd1Lauper" | npm run decrypt
 
 # diff the two files, and exit with its length
 comm -3 config.json config.copy.json | wc -c | exit
+
+# encyrpt using a password stored in the ENV_PW environmental variable
+npm run encrypt_env
+
+# decrypt using a password stored in the ENV_PW environmental variable
+npm run decrypt_env
+
+# diff the two files, and exit with its length
+comm -3 config.json config.copy.json | wc -c | exit


### PR DESCRIPTION
I've had a difficult time integrating this module into some continuous delivery pipelines like PM2 because for some reason (I really don't know why) piping a password using echo (`echo 'my_pass' | npm run encrypt`) doesn't work in the isolated environments set up to build and deploy code.

To get around this, I've added support for a single flag `--PW` to which you pass the name of an environmental variable set to a desired password.

Example use in `package.json`: `encrypt: encrypt config.json config.json.cast5 --PW=ENV_VAR`

This by-passes manual password entry from stdin and instead uses the value found at the --PW environmental variable, if it exits. If the environmental variable is not set, the command exits with exit status 1.
