### PR TITLE
Replace readline with prompt to improve compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = function(fn) {
     });
 
     rl.question(query, function(value) {
-        rl.history = rl.history.slice(1);
+        rl.history = (rl.history || []).slice(1);
         callback(value);
     });
   }

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ module.exports = function(fn) {
       from.pipe(fn).pipe(to);
       from.on("end", function () {
         console.log("done");
+        prompt.stop();
       });
     }
   });

--- a/index.js
+++ b/index.js
@@ -1,51 +1,19 @@
-var crypto   = require("crypto")
-var fs       = require("fs")
-var readline = require("readline")
-var path     = require("path")
+var crypto        = require("crypto");
+var fs            = require("fs");
+var readlineSync  = require("readline-sync");
+var path          = require("path");
 
 module.exports = function(fn) {
-  var from = path.join(process.cwd(), process.argv[2])
-  var to   = path.join(process.cwd(), process.argv[3])
+  var from = path.join(process.cwd(), process.argv[2]);
+  var to   = path.join(process.cwd(), process.argv[3]);
 
-  var rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout
-  })
-
-  var input = function(query, callback) {
-    var stdin = process.openStdin(),
-        i = 0;
-    process.stdin.on("data", function(char) {
-        char = char + "";
-        switch (char) {
-            case "\n":
-            case "\r":
-            case "\u0004":
-                stdin.pause();
-                break;
-            default:
-                process.stdout.write("\033[2K\033[200D" + Array(rl.line.length+1).join("*"));
-		i++;
-                break;
-        }
-    });
-
-    rl.question(query, function(value) {
-        rl.history = (rl.history || []).slice(1);
-        callback(value);
-    });
-  }
+  var password = readlineSync.question("Enter the config password (" + path.basename(to) + "):\n", {
+    hideEchoBack: true 
+  });
   
-  input("Enter the config password ("+path.basename(to)+"):\n", function(password) {
-    from = fs.createReadStream(from)
-    to   = fs.createWriteStream(to)
-    fn   = fn("cast5-cbc", password)
-
-    from.pipe(fn).pipe(to)
-    from.on("end", function () {
-      rl.write("done\n");
-      rl.close.bind(rl);
-    });
-    
-  })
-}
+  from = fs.createReadStream(from);
+  to   = fs.createWriteStream(to);
+  fn   = fn("cast5-cbc", password);
+  
+  from.pipe(fn).pipe(to);
+};

--- a/index.js
+++ b/index.js
@@ -1,19 +1,35 @@
-var crypto        = require("crypto");
-var fs            = require("fs");
-var readlineSync  = require("readline-sync");
-var path          = require("path");
+var crypto    = require("crypto");
+var fs        = require("fs");
+var prompt    = require("prompt");
+var path      = require("path");
 
 module.exports = function(fn) {
   var from = path.join(process.cwd(), process.argv[2]);
   var to   = path.join(process.cwd(), process.argv[3]);
 
-  var password = readlineSync.question("Enter the config password (" + path.basename(to) + "):\n", {
-    hideEchoBack: true 
+  prompt.start();
+  
+  prompt.get([
+    {
+      description: "Enter the config password (" + path.basename(to) + "):\n",
+      name: "password",
+      type: "string",
+      hidden: true,
+      replace: "*",
+      required: true
+    }
+  ], function (err, result) {
+    if (err) {
+      console.log(err);
+    } else {
+      from = fs.createReadStream(from);
+      to   = fs.createWriteStream(to);
+      fn   = fn("cast5-cbc", result.password);
+      
+      from.pipe(fn).pipe(to);
+      from.on("end", function () {
+        console.log("done");
+      });
+    }
   });
-  
-  from = fs.createReadStream(from);
-  to   = fs.createWriteStream(to);
-  fn   = fn("cast5-cbc", password);
-  
-  from.pipe(fn).pipe(to);
 };

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
   },
   "engines": {
     "node": ">=0.10.0"
+  },
+  "dependencies": {
+    "readline-sync": "^1.4.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "node": ">=0.10.0"
   },
   "dependencies": {
-    "readline-sync": "^1.4.4"
+    "prompt": "^1.0.0"
   }
 }


### PR DESCRIPTION
The current version has compatibility issues with some terminals like Git Bash, this is due to the password masking code that was introduced in 0.2.0. The current solution is utilizing undocumented properties (_history_, _line_) of Node's **readline.Interface**. Patching the current solution to address #6 was unsuccessful, so I propose replacing **readline** with **prompt**. This will make the solution more robust and I have confirmed it was address the compatibility issues that came about in #6 .